### PR TITLE
QoL: Use path.resolve instead of manual path concatenation on backend

### DIFF
--- a/backend/src/controllers/api.ts
+++ b/backend/src/controllers/api.ts
@@ -1,14 +1,15 @@
 import * as async from 'async';
 import * as request from 'request';
 import * as fs from 'fs';
+import * as path from 'path';
 import {Response, Request, NextFunction} from 'express';
 import {config} from '../config';
 
 
 export let getAllFiles = (req: Request, res: Response) => {
 	res.json({
-		images: listAllFiles(config.pathToCrosscode + 'media/', [], 'png'),
-		data: listAllFiles(config.pathToCrosscode + 'data/', [], 'json')
+		images: listAllFiles(path.resolve(config.pathToCrosscode, 'media/'), [], 'png'),
+		data: listAllFiles(path.resolve(config.pathToCrosscode, 'data/'), [], 'json')
 	});
 };
 
@@ -16,10 +17,10 @@ function listAllFiles(dir: string, filelist, ending: string): string[] {
 	const files = fs.readdirSync(dir);
 	filelist = filelist || [];
 	files.forEach(function (file) {
-		if (fs.statSync(dir + file).isDirectory()) {
-			filelist = listAllFiles(dir + file + '/', filelist, ending);
+		if (fs.statSync(path.resolve(dir, file)).isDirectory()) {
+			filelist = listAllFiles(path.resolve(dir, file), filelist, ending);
 		} else if (!ending || file.toLowerCase().endsWith(ending.toLowerCase())) {
-			filelist.push((dir + file).split(config.pathToCrosscode)[1]);
+			filelist.push(path.resolve(dir, file).split(config.pathToCrosscode)[1]);
 		}
 	});
 	return filelist;


### PR DESCRIPTION
This PR makes the existing backend API more robust, and fixes obscure bugs when giving certain "valid" values to `pathToCrosscode`, by using `path.resolve`(which works around certain OS-specific quirks automatically) instead of concatenating paths manually when listing all files.