### PR TITLE
Fix character selector NPC preview direction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Fixed
+- Character selector previews now render NPCs facing south when no face direction is explicitly configured.
+
 ## [2.4.2] 2026-05-23
 ### Fixed
 - Improved NPC rendering, positions should now match the game exactly [#130](https://github.com/CCDirectLink/crosscode-map-editor/issues/130), [#132](https://github.com/CCDirectLink/crosscode-map-editor/issues/132)

--- a/webapp/src/app/components/widgets/character-widget/character-widget.component.ts
+++ b/webapp/src/app/components/widgets/character-widget/character-widget.component.ts
@@ -121,7 +121,10 @@ export class CharacterWidgetComponent extends OverlayWidget {
 			const prop: typeof this.props[0] = {
 				prefix: char.split('.')[0],
 				full: char,
-				img: await this.generateImage<NpcAttributes>({characterName: char}, 'NPC')
+				img: await this.generateImage<NpcAttributes>({
+					characterName: char,
+					npcStates: [{face: 'SOUTH'}]
+				}, 'NPC')
 			};
 			return prop;
 		}));


### PR DESCRIPTION
### Motivation
- The runtime now defaults NPC face to `NORTH` when missing, but the character selector thumbnails should still present characters facing `SOUTH` to make selection easier.

### Description
- Pass `npcStates: [{ face: 'SOUTH' }]` into `generateImage` when building selector thumbnails in `webapp/src/app/components/widgets/character-widget/character-widget.component.ts` so previews consistently face south.

### Testing
- Ran `npm -C webapp run lint`, which completed successfully (`All files pass linting`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12f2cbe1d0832fba2118b288780290)